### PR TITLE
Fix API URL

### DIFF
--- a/Get-EUVD.py
+++ b/Get-EUVD.py
@@ -95,7 +95,7 @@ with open(LOCK_FILE, "w") as lock_file:
 
     while True:
         url = (
-            "https://euvdservices.enisa.europa.eu/api/vulnerabilities"
+            "https://euvdservices.enisa.europa.eu/api/search"
             f"?fromDate={from_date}&toDate={to_date}&page={page}&size={page_size}"
         )
 


### PR DESCRIPTION
Apparently, the API URL has been changed in the last weeks: https://euvd.enisa.europa.eu/apidoc